### PR TITLE
cmake: changed NET_DSA dependency

### DIFF
--- a/drivers/ethernet/Kconfig.dsa
+++ b/drivers/ethernet/Kconfig.dsa
@@ -6,10 +6,9 @@
 
 menuconfig NET_DSA
 	bool "Distributed Switch Architecture support"
-	depends on ETH_MCUX
+	depends on NET_L2_ETHERNET
 	help
-	  Enable Distributed Switch Architecture support. For now it
-	  only supports Kinetics ENET driver.
+	  Enable Distributed Switch Architecture support.
 
 if NET_DSA
 


### PR DESCRIPTION
Changed the dependency into NET_L2_ETHERNET to allow enabling without NXP MCUX

Signed-off-by: Hein Wessels <hein.wessels@nobleo.nl>