### PR TITLE
Clock Control: Enable MCO for STM32H7

### DIFF
--- a/drivers/clock_control/Kconfig.stm32
+++ b/drivers/clock_control/Kconfig.stm32
@@ -208,25 +208,25 @@ config CLOCK_STM32_MCO1_SRC_NOCLOCK
 
 config CLOCK_STM32_MCO1_SRC_LSE
 	bool "LSE"
-	depends on SOC_SERIES_STM32F4X
+	depends on SOC_SERIES_STM32F4X || SOC_SERIES_STM32H7X
 	help
 	  Use LSE as source of MCO1
 
 config CLOCK_STM32_MCO1_SRC_HSE
 	bool "HSE"
-	depends on SOC_SERIES_STM32F4X
+	depends on SOC_SERIES_STM32F4X || SOC_SERIES_STM32H7X
 	help
 	  Use HSE as source of MCO1
 
 config CLOCK_STM32_MCO1_SRC_HSI
 	bool "HSI"
-	depends on SOC_SERIES_STM32F4X
+	depends on SOC_SERIES_STM32F4X || SOC_SERIES_STM32H7X
 	help
 	  Use HSI as source of MCO1
 
 config CLOCK_STM32_MCO1_SRC_PLLCLK
 	bool "PLLCLK"
-	depends on SOC_SERIES_STM32F4X
+	depends on SOC_SERIES_STM32F4X || SOC_SERIES_STM32H7X
 	help
 	  Use PLLCLK as source of MCO1
 
@@ -251,25 +251,25 @@ config CLOCK_STM32_MCO2_SRC_NOCLOCK
 
 config CLOCK_STM32_MCO2_SRC_SYSCLK
 	bool "SYSCLK"
-	depends on SOC_SERIES_STM32F4X
+	depends on SOC_SERIES_STM32F4X || SOC_SERIES_STM32H7X
 	help
 	  Use SYSCLK as source of MCO2
 
 config CLOCK_STM32_MCO2_SRC_PLLI2S
 	bool "PLLI2S"
-	depends on SOC_SERIES_STM32F4X
+	depends on SOC_SERIES_STM32F4X || SOC_SERIES_STM32H7X
 	help
 	  Use PLLI2S as source of MCO2
 
 config CLOCK_STM32_MCO2_SRC_HSE
 	bool "HSE"
-	depends on SOC_SERIES_STM32F4X
+	depends on SOC_SERIES_STM32F4X || SOC_SERIES_STM32H7X
 	help
 	  Use HSE as source of MCO2
 
 config CLOCK_STM32_MCO2_SRC_PLLCLK
 	bool "PLLCLK"
-	depends on SOC_SERIES_STM32F4X
+	depends on SOC_SERIES_STM32F4X || SOC_SERIES_STM32H7X
 	help
 	  Use PLLCLK as source of MCO2
 

--- a/drivers/clock_control/clock_stm32_ll_h7.c
+++ b/drivers/clock_control/clock_stm32_ll_h7.c
@@ -15,6 +15,7 @@
 #include <sys/util.h>
 #include <drivers/clock_control/stm32_clock_control.h>
 #include "stm32_hsem.h"
+#include "clock_stm32_ll_common.h"
 
 /* Macros to fill up prescaler values */
 #define z_hsi_divider(v) LL_RCC_HSI_DIV ## v
@@ -37,6 +38,12 @@
 
 #define z_apb4_prescaler(v) LL_RCC_APB4_DIV_ ## v
 #define apb4_prescaler(v) z_apb4_prescaler(v)
+
+#define z_mco1_prescaler(v) LL_RCC_MCO1_DIV_ ## v
+#define mco1_prescaler(v) z_mco1_prescaler(v)
+
+#define z_mco2_prescaler(v) LL_RCC_MCO2_DIV_ ## v
+#define mco2_prescaler(v) z_mco2_prescaler(v)
 
 /* Macro to check for clock feasability */
 /* It is Cortex M7's responsibility to setup clock tree */
@@ -724,6 +731,16 @@ static int stm32_clock_control_init(const struct device *dev)
 	SysTick_Config(CONFIG_SYS_CLOCK_HW_CYCLES_PER_SEC / 1000);
 	/* Update CMSIS variable */
 	SystemCoreClock = CONFIG_SYS_CLOCK_HW_CYCLES_PER_SEC;
+
+#ifndef CONFIG_CLOCK_STM32_MCO1_SRC_NOCLOCK
+	LL_RCC_ConfigMCO(MCO1_SOURCE,
+			 mco1_prescaler(CONFIG_CLOCK_STM32_MCO1_DIV));
+#endif /* CONFIG_CLOCK_STM32_MCO1_SRC_NOCLOCK */
+
+#ifndef CONFIG_CLOCK_STM32_MCO2_SRC_NOCLOCK
+	LL_RCC_ConfigMCO(MCO2_SOURCE,
+			 mco2_prescaler(CONFIG_CLOCK_STM32_MCO2_DIV));
+#endif /* CONFIG_CLOCK_STM32_MCO2_SRC_NOCLOCK */
 
 	return 0;
 }

--- a/drivers/ethernet/Kconfig.dsa
+++ b/drivers/ethernet/Kconfig.dsa
@@ -6,10 +6,9 @@
 
 menuconfig NET_DSA
 	bool "Distributed Switch Architecture support"
-	depends on ETH_MCUX
+	depends on NET_L2_ETHERNET
 	help
-	  Enable Distributed Switch Architecture support. For now it
-	  only supports Kinetics ENET driver.
+	  Enable Distributed Switch Architecture support.
 
 if NET_DSA
 


### PR DESCRIPTION
Expanded STM32H7 clock control to

to allow enabling the MCO output

Signed-off-by: Hein Wessels <hein.wessels@nobleo.nl>