### PR TITLE
drivers: ethernet: stm32: SRAM3 / MPU configuration

### DIFF
--- a/drivers/ethernet/eth_stm32_hal.c
+++ b/drivers/ethernet/eth_stm32_hal.c
@@ -67,24 +67,27 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 
 #if defined(CONFIG_ETH_STM32_HAL_USE_DTCM_FOR_DMA_BUFFER) && \
 	    DT_NODE_HAS_STATUS(DT_CHOSEN(zephyr_dtcm), okay)
-#define ETH_DMA_MEM	__dtcm_noinit_section
+#define __eth_stm32_desc __dtcm_noinit_section
+#define __eth_stm32_buf  __dtcm_noinit_section
+#elif defined(CONFIG_SOC_SERIES_STM32H7X) && \
+		DT_NODE_HAS_STATUS(DT_NODELABEL(sram3), okay)
+#define __eth_stm32_desc __attribute__((section(".eth_stm32_desc")))
+#define __eth_stm32_buf  __attribute__((section(".eth_stm32_buf")))
+#elif defined(CONFIG_NOCACHE_MEMORY)
+#define __eth_stm32_desc __nocache __aligned(4)
+#define __eth_stm32_buf  __nocache __aligned(4)
 #else
-#define ETH_DMA_MEM	__aligned(4)
-#endif /* CONFIG_ETH_STM32_HAL_USE_DTCM_FOR_DMA_BUFFER */
-
-#if defined(CONFIG_NOCACHE_MEMORY)
-#define CACHE __nocache
-#else
-#define CACHE
+#define __eth_stm32_desc __aligned(4)
+#define __eth_stm32_buf  __aligned(4)
 #endif
 
-static ETH_DMADescTypeDef dma_rx_desc_tab[ETH_RXBUFNB] CACHE ETH_DMA_MEM;
-static ETH_DMADescTypeDef dma_tx_desc_tab[ETH_TXBUFNB] CACHE ETH_DMA_MEM;
-static uint8_t dma_rx_buffer[ETH_RXBUFNB][ETH_RX_BUF_SIZE] CACHE ETH_DMA_MEM;
-static uint8_t dma_tx_buffer[ETH_TXBUFNB][ETH_TX_BUF_SIZE] CACHE ETH_DMA_MEM;
+static ETH_DMADescTypeDef dma_rx_desc_tab[ETH_RXBUFNB] __eth_stm32_desc;
+static ETH_DMADescTypeDef dma_tx_desc_tab[ETH_TXBUFNB] __eth_stm32_desc;
+static uint8_t dma_rx_buffer[ETH_RXBUFNB][ETH_RX_BUF_SIZE] __eth_stm32_buf;
+static uint8_t dma_tx_buffer[ETH_TXBUFNB][ETH_TX_BUF_SIZE] __eth_stm32_buf;
 
 #if defined(CONFIG_SOC_SERIES_STM32H7X)
-static ETH_TxPacketConfig tx_config CACHE;
+static ETH_TxPacketConfig tx_config;
 #endif
 
 #if defined(CONFIG_NET_L2_CANBUS_ETH_TRANSLATOR)

--- a/soc/arm/st_stm32/stm32h7/CMakeLists.txt
+++ b/soc/arm/st_stm32/stm32h7/CMakeLists.txt
@@ -4,3 +4,6 @@ zephyr_include_directories(${ZEPHYR_BASE}/drivers)
 
 zephyr_sources_ifdef(CONFIG_CPU_CORTEX_M7 soc_m7.c)
 zephyr_sources_ifdef(CONFIG_CPU_CORTEX_M4 soc_m4.c)
+
+zephyr_sources(mpu_regions.c)
+zephyr_linker_sources(SECTIONS sections.ld)

--- a/soc/arm/st_stm32/stm32h7/Kconfig.series
+++ b/soc/arm/st_stm32/stm32h7/Kconfig.series
@@ -13,6 +13,7 @@ config SOC_SERIES_STM32H7X
 	select CPU_HAS_ARM_MPU
 	select HAS_SWO
 	select USE_STM32_HAL_CORTEX
+	select CPU_HAS_CUSTOM_FIXED_SOC_MPU_REGIONS
 	help
 	  Enable support for STM32H7 MCU series
 

--- a/soc/arm/st_stm32/stm32h7/mpu_regions.c
+++ b/soc/arm/st_stm32/stm32h7/mpu_regions.c
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2020 Mario Jaun
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <devicetree.h>
+#include "../../common/cortex_m/arm_mpu_mem_cfg.h"
+
+static const struct arm_mpu_region mpu_regions[] = {
+	MPU_REGION_ENTRY("FLASH", CONFIG_FLASH_BASE_ADDRESS,
+					 REGION_FLASH_ATTR(REGION_FLASH_SIZE)),
+	MPU_REGION_ENTRY("SRAM", CONFIG_SRAM_BASE_ADDRESS,
+					 REGION_RAM_ATTR(REGION_SRAM_SIZE)),
+#if DT_NODE_HAS_STATUS(DT_NODELABEL(sram3), okay) && \
+		DT_NODE_HAS_STATUS(DT_NODELABEL(mac), okay)
+	MPU_REGION_ENTRY("SRAM3_ETH_BUF",
+					 DT_REG_ADDR(DT_NODELABEL(sram3)),
+					 REGION_RAM_NOCACHE_ATTR(REGION_16K)),
+	MPU_REGION_ENTRY("SRAM3_ETH_DESC",
+					 DT_REG_ADDR(DT_NODELABEL(sram3)),
+					 REGION_PPB_ATTR(REGION_256B)),
+#endif
+};
+
+const struct arm_mpu_config mpu_config = {
+	.num_regions = ARRAY_SIZE(mpu_regions),
+	.mpu_regions = mpu_regions,
+};

--- a/soc/arm/st_stm32/stm32h7/sections.ld
+++ b/soc/arm/st_stm32/stm32h7/sections.ld
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2020 Mario Jaun
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#if DT_NODE_HAS_STATUS(DT_NODELABEL(sram3), okay) && DT_NODE_HAS_STATUS(DT_NODELABEL(mac), okay)
+
+SECTION_DATA_PROLOGUE(eth_stm32,(NOLOAD),)
+{
+    . = ABSOLUTE(DT_REG_ADDR(DT_NODELABEL(sram3)));
+    *(.eth_stm32_desc)
+    . = ABSOLUTE(DT_REG_ADDR(DT_NODELABEL(sram3))) + 256;
+    *(.eth_stm32_buf)
+    . = ABSOLUTE(DT_REG_ADDR(DT_NODELABEL(sram3))) + 16K;
+} GROUP_DATA_LINK_IN(SRAM3, SRAM3)
+
+#endif


### PR DESCRIPTION
Fixes #29915.

Implements the memory layout and MPU configuration for Ethernet buffers
for STM32H7 controllers as recommended by ST. 16 KB of SRAM3 are
are reserved for this. The first 256 B are for the RX/TX descriptors and
configured as strongly ordered, shareable memory. The rest is for RX/TX
buffers and configured as non cacheable memory. This configuration is
automatically applied for H7 chips if the SRAM3 memory is enabled in the
device tree.

Signed-off-by: Mario Jaun <mario.jaun@gmail.com>