### PR TITLE
stm32: drivers: flash: mcumgr: support for H7

### DIFF
--- a/drivers/adc/adc_stm32.c
+++ b/drivers/adc/adc_stm32.c
@@ -370,6 +370,7 @@ static int start_read(const struct device *dev,
 	 * NOTE: There is no LL API to control this register yet.
 	 */
 #if defined(ADC_VER_V5_V90)
+	/* ADC3 has no preselection register */
 	if (adc != ADC3) {
 		adc->PCSEL_RES0 |= channels & ADC_PCSEL_PCSEL_Msk;
 	}

--- a/drivers/flash/Kconfig
+++ b/drivers/flash/Kconfig
@@ -58,6 +58,12 @@ config FLASH_PAGE_LAYOUT
 	help
 	  Enables API for retrieving the layout of flash memory pages.
 
+config FLASH_ALIGNMENT_WORD_SIZE_BYTES
+	int "Size of the flash word"
+	default 8
+	help
+	  Sets the alignment size of a flash word.
+
 source "drivers/flash/Kconfig.at45"
 
 source "drivers/flash/Kconfig.esp32"

--- a/drivers/flash/flash_stm32_qspi.c
+++ b/drivers/flash/flash_stm32_qspi.c
@@ -1092,10 +1092,10 @@ static int flash_stm32_qspi_init(const struct device *dev)
 	}
 	LOG_DBG("Set quad output: %s", STM32_QSPI_USE_FOUR_DATALINES ? "true" : "false");
 
-	LOG_DBG("Device %s initialized", DEV_NAME(dev));
-
 	/* wait until quad output is set before doing an immediate read/write call */
 	qspi_wait_until_ready(dev);
+
+	LOG_DBG("Device %s initialized", DEV_NAME(dev));
 
 	return 0;
 }

--- a/drivers/flash/flash_stm32_qspi.c
+++ b/drivers/flash/flash_stm32_qspi.c
@@ -1094,6 +1094,9 @@ static int flash_stm32_qspi_init(const struct device *dev)
 
 	LOG_DBG("Device %s initialized", DEV_NAME(dev));
 
+	/* wait until quad output is set before doing an immediate read/write call */
+	qspi_wait_until_ready(dev);
+
 	return 0;
 }
 

--- a/drivers/flash/flash_stm32h7x.c
+++ b/drivers/flash/flash_stm32h7x.c
@@ -93,7 +93,7 @@ bool flash_stm32_valid_range(const struct device *dev, off_t offset,
 		 */
 		if ((offset < BANK2_OFFSET)
 		    && (offset + len > REAL_FLASH_SIZE_KB / 2)) {
-			LOG_ERR("Range ovelaps flash bank discontinuity");
+			LOG_ERR("Range overlaps flash bank discontinuity");
 			return false;
 		}
 	}

--- a/include/dfu/mcuboot.h
+++ b/include/dfu/mcuboot.h
@@ -65,9 +65,16 @@ extern "C" {
 #define BOOT_IMG_VER_STRLEN_MAX 25  /* 255.255.65535.4294967295\0 */
 
 /* Trailer: */
-#define BOOT_MAX_ALIGN		8
+#ifndef CONFIG_FLASH_ALIGNMENT_WORD_SIZE_BYTES
+#warning "expecting flash alignment to be defined, using 8 bytes as default"
+#define CONFIG_FLASH_ALIGNMENT_WORD_SIZE_BYTES 8
+#endif
+
+#define BOOT_MAX_ALIGN          CONFIG_FLASH_ALIGNMENT_WORD_SIZE_BYTES
+
 #ifndef BOOT_MAGIC_SZ
-#define BOOT_MAGIC_SZ		16
+#define BOOT_MAGIC_SZ (CONFIG_FLASH_ALIGNMENT_WORD_SIZE_BYTES > 16 ?\
+						CONFIG_FLASH_ALIGNMENT_WORD_SIZE_BYTES : 16)
 #endif
 
 #define BOOT_TRAILER_IMG_STATUS_OFFS(bank_area) ((bank_area)->fa_size -\

--- a/include/mgmt/mcumgr/buf.h
+++ b/include/mgmt/mcumgr/buf.h
@@ -8,17 +8,18 @@
 #define ZEPHYR_INCLUDE_MGMT_BUF_H_
 
 #include <inttypes.h>
-#include "tinycbor/cbor.h"
-#include "tinycbor/cbor_buf_writer.h"
+#include "cbor.h"
+
 struct net_buf;
 
 struct cbor_nb_reader {
-	struct cbor_decoder_reader r;
+	CborParser parser;
+	CborValue it;
 	struct net_buf *nb;
 };
 
 struct cbor_nb_writer {
-	struct cbor_encoder_writer enc;
+	CborEncoder encoder;
 	struct net_buf *nb;
 };
 

--- a/samples/subsys/mgmt/mcumgr/smp_svr/CMakeLists.txt
+++ b/samples/subsys/mgmt/mcumgr/smp_svr/CMakeLists.txt
@@ -12,6 +12,8 @@ cmake_minimum_required(VERSION 3.13.1)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(smp_svr)
 
+zephyr_compile_definitions(CBOR_NO_FLOATING_POINT=1 CBOR_NO_HALF_FLOAT_TYPE=1)
+
 target_sources(app PRIVATE src/main.c)
 target_sources_ifdef(CONFIG_MCUMGR_SMP_BT app PRIVATE src/bluetooth.c)
 target_sources_ifdef(CONFIG_MCUMGR_SMP_UDP app PRIVATE src/udp.c)

--- a/subsys/mgmt/mcumgr/buf.c
+++ b/subsys/mgmt/mcumgr/buf.c
@@ -7,7 +7,6 @@
 #include <string.h>
 #include "net/buf.h"
 #include "mgmt/mcumgr/buf.h"
-#include <tinycbor/compilersupport_p.h>
 
 NET_BUF_POOL_DEFINE(pkt_pool, CONFIG_MCUMGR_BUF_COUNT, CONFIG_MCUMGR_BUF_SIZE,
 		    CONFIG_MCUMGR_BUF_USER_DATA_SIZE, NULL);
@@ -24,133 +23,19 @@ mcumgr_buf_free(struct net_buf *nb)
 	net_buf_unref(nb);
 }
 
-static uint8_t
-cbor_nb_reader_get8(struct cbor_decoder_reader *d, int offset)
-{
-	struct cbor_nb_reader *cnr;
-
-	cnr = (struct cbor_nb_reader *) d;
-
-	if (offset < 0 || offset >= cnr->nb->len) {
-		return UINT8_MAX;
-	}
-
-	return cnr->nb->data[offset];
-}
-
-static uint16_t
-cbor_nb_reader_get16(struct cbor_decoder_reader *d, int offset)
-{
-	struct cbor_nb_reader *cnr;
-	uint16_t val;
-
-	cnr = (struct cbor_nb_reader *) d;
-
-	if (offset < 0 || offset > cnr->nb->len - (int)sizeof(val)) {
-		return UINT16_MAX;
-	}
-
-	memcpy(&val, cnr->nb->data + offset, sizeof(val));
-	return cbor_ntohs(val);
-}
-
-static uint32_t
-cbor_nb_reader_get32(struct cbor_decoder_reader *d, int offset)
-{
-	struct cbor_nb_reader *cnr;
-	uint32_t val;
-
-	cnr = (struct cbor_nb_reader *) d;
-
-	if (offset < 0 || offset > cnr->nb->len - (int)sizeof(val)) {
-		return UINT32_MAX;
-	}
-
-	memcpy(&val, cnr->nb->data + offset, sizeof(val));
-	return cbor_ntohl(val);
-}
-
-static uint64_t
-cbor_nb_reader_get64(struct cbor_decoder_reader *d, int offset)
-{
-	struct cbor_nb_reader *cnr;
-	uint64_t val;
-
-	cnr = (struct cbor_nb_reader *) d;
-
-	if (offset < 0 || offset > cnr->nb->len - (int)sizeof(val)) {
-		return UINT64_MAX;
-	}
-
-	memcpy(&val, cnr->nb->data + offset, sizeof(val));
-	return cbor_ntohll(val);
-}
-
-static uintptr_t
-cbor_nb_reader_cmp(struct cbor_decoder_reader *d, char *buf, int offset,
-		   size_t len)
-{
-	struct cbor_nb_reader *cnr;
-
-	cnr = (struct cbor_nb_reader *) d;
-
-	if (offset < 0 || offset > cnr->nb->len - (int)len) {
-		return -1;
-	}
-
-	return memcmp(cnr->nb->data + offset, buf, len);
-}
-
-static uintptr_t
-cbor_nb_reader_cpy(struct cbor_decoder_reader *d, char *dst, int offset,
-		   size_t len)
-{
-	struct cbor_nb_reader *cnr;
-
-	cnr = (struct cbor_nb_reader *) d;
-
-	if (offset < 0 || offset > cnr->nb->len - (int)len) {
-		return -1;
-	}
-
-	return (uintptr_t)memcpy(dst, cnr->nb->data + offset, len);
-}
-
 void
 cbor_nb_reader_init(struct cbor_nb_reader *cnr,
 		    struct net_buf *nb)
 {
-	cnr->r.get8 = &cbor_nb_reader_get8;
-	cnr->r.get16 = &cbor_nb_reader_get16;
-	cnr->r.get32 = &cbor_nb_reader_get32;
-	cnr->r.get64 = &cbor_nb_reader_get64;
-	cnr->r.cmp = &cbor_nb_reader_cmp;
-	cnr->r.cpy = &cbor_nb_reader_cpy;
-
 	cnr->nb = nb;
-	cnr->r.message_size = nb->len;
-}
-
-static int
-cbor_nb_write(struct cbor_encoder_writer *writer, const char *data, int len)
-{
-	struct cbor_nb_writer *cnw;
-
-	cnw = (struct cbor_nb_writer *) writer;
-	if (len > net_buf_tailroom(cnw->nb)) {
-		return CborErrorOutOfMemory;
-	}
-
-	net_buf_add_mem(cnw->nb, data, len);
-	cnw->enc.bytes_written += len;
-
-	return CborNoError;
+	/* here we give the actual size of the encoded data to the parser, so nb->len */
+	cbor_parser_init(nb->data, nb->len, 0, &cnr->parser, &cnr->it);
 }
 
 void
 cbor_nb_writer_init(struct cbor_nb_writer *cnw, struct net_buf *nb)
 {
 	cnw->nb = nb;
-	cnw->enc.bytes_written = 0;
-	cnw->enc.write = &cbor_nb_write;
+	/* here we give the max size of the encoding buffer to the encoder, so nb->size */
+	cbor_encoder_init(&cnw->encoder, nb->data, nb->size, 0);
 }

--- a/subsys/mgmt/mcumgr/smp_bt.c
+++ b/subsys/mgmt/mcumgr/smp_bt.c
@@ -55,6 +55,9 @@ static ssize_t smp_bt_chr_write(struct bt_conn *conn,
 	struct net_buf *nb;
 
 	nb = mcumgr_buf_alloc();
+	if (!nb) {
+		return BT_GATT_ERR(BT_ATT_ERR_INSUFFICIENT_RESOURCES);
+	}
 	net_buf_add_mem(nb, buf, len);
 
 	ud = net_buf_user_data(nb);

--- a/subsys/mgmt/mcumgr/smp_udp.c
+++ b/subsys/mgmt/mcumgr/smp_udp.c
@@ -121,6 +121,11 @@ static void smp_udp_receive_thread(void *p1, void *p2, void *p3)
 
 			/* store sender address in user data for reply */
 			nb = mcumgr_buf_alloc();
+			if (!nb) {
+				LOG_ERR("Failed to allocate mcumgr buffer");
+				/* No free space, drop smp frame */
+				continue;
+			}
 			net_buf_add_mem(nb, conf->recv_buffer, len);
 			ud = net_buf_user_data(nb);
 			net_ipaddr_copy(ud, &addr);

--- a/west.yml
+++ b/west.yml
@@ -127,7 +127,7 @@ manifest:
       path: modules/lib/tinycbor
       repo-path: tinycbor
       remote: optima
-      revision: 69e745dd9d4975a770ca70195f61510b43e125d4
+      revision: 7e9cd89091b196ab7c0486b2a768c3725ffedde6
     - name: tinycrypt
       path: modules/crypto/tinycrypt
       revision: 3e9a49d2672ec01435ffbf0d788db6d95ef28de0

--- a/west.yml
+++ b/west.yml
@@ -21,6 +21,8 @@ manifest:
   remotes:
     - name: upstream
       url-base: https://github.com/zephyrproject-rtos
+    - name: optima
+      url-base: https://github.com/fancom
 
   #
   # Please add items below based on alphabetical order
@@ -91,10 +93,14 @@ manifest:
       revision: 5765cb7f75a9973ae9232d438e361a9d7bbc49e7
       path: modules/crypto/mbedtls
     - name: mcuboot
-      revision: 2fce9769b191411d580bbc65b043956c2ae9307e
+      repo-path: mcuboot
+      remote: optima
+      revision: 5a173faff03ae8711d216204f7e925674c5da9a1
       path: bootloader/mcuboot
     - name: mcumgr
-      revision: 5c5055f5a7565f8152d75fcecf07262928b4d56e
+      repo-path: mynewt-mcumgr
+      remote: optima
+      revision: 5aa48ad52204430e51ea2872b3bac0ebb4a331f6
       path: modules/lib/mcumgr
     - name: net-tools
       revision: f49bd1354616fae4093bf36e5eaee43c51a55127
@@ -119,7 +125,9 @@ manifest:
       path: modules/audio/sof
     - name: tinycbor
       path: modules/lib/tinycbor
-      revision: 40daca97b478989884bffb5226e9ab73ca54b8c4
+      repo-path: tinycbor
+      remote: optima
+      revision: 69e745dd9d4975a770ca70195f61510b43e125d4
     - name: tinycrypt
       path: modules/crypto/tinycrypt
       revision: 3e9a49d2672ec01435ffbf0d788db6d95ef28de0


### PR DESCRIPTION
Add support for setting flash word alignment size.
Update to tinycbor 0.5.4 for mcumgr (https://github.com/fancom/tinycbor/pull/1).

Signed-off-by: Jeroen van Dooren <jeroen.van.dooren@nobleo.nl>