### PR TITLE
Feature/fop 3265/update zephyr adc

### DIFF
--- a/drivers/adc/adc_stm32.c
+++ b/drivers/adc/adc_stm32.c
@@ -367,17 +367,9 @@ static int start_read(const struct device *dev,
 	/*
 	 * Each channel in the sequence must be previously enabled in PCSEL.
 	 * This register controls the analog switch integrated in the IO level.
-	 * NOTE: There is no LL API to control this register yet.
 	 */
-#if defined(ADC_VER_V5_V90)
-	/* ADC3 has no preselection register */
-	if (adc != ADC3) {
-		adc->PCSEL_RES0 |= channels & ADC_PCSEL_PCSEL_Msk;
-	}
-#else
-	adc->PCSEL |= channels & ADC_PCSEL_PCSEL_Msk;
-#endif /* ADC_VER_V5_V90 */
-#endif /* CONFIG_SOC_SERIES_STM32H7X */
+	LL_ADC_SetChannelPreSelection(adc, channel);
+#endif
 
 #if defined(CONFIG_SOC_SERIES_STM32F0X) || \
 	defined(CONFIG_SOC_SERIES_STM32L0X)

--- a/drivers/adc/adc_stm32.c
+++ b/drivers/adc/adc_stm32.c
@@ -498,6 +498,15 @@ static int start_read(const struct device *dev,
 	case 8:
 		adc_stm32_oversampling(adc, 8, LL_ADC_OVS_SHIFT_RIGHT_8);
 		break;
+#if defined(CONFIG_SOC_SERIES_STM32H7X)
+	/* stm32 H7 ADC1 & 2 have oversampling ratio from 1..1024 */
+	case 9:
+		adc_stm32_oversampling(adc, 9, LL_ADC_OVS_SHIFT_RIGHT_9);
+		break;
+	case 10:
+		adc_stm32_oversampling(adc, 10, LL_ADC_OVS_SHIFT_RIGHT_10);
+		break;
+#endif /* CONFIG_SOC_SERIES_STM32H7X */
 	default:
 		LOG_ERR("Invalid oversampling");
 		return -EINVAL;

--- a/drivers/adc/adc_stm32.c
+++ b/drivers/adc/adc_stm32.c
@@ -302,6 +302,60 @@ static void adc_stm32_calib(const struct device *dev)
 }
 #endif
 
+#if defined(CONFIG_SOC_SERIES_STM32G0X) || \
+	defined(CONFIG_SOC_SERIES_STM32G4X) || \
+	defined(CONFIG_SOC_SERIES_STM32H7X) || \
+	defined(CONFIG_SOC_SERIES_STM32L0X) || \
+	defined(CONFIG_SOC_SERIES_STM32L4X) || \
+	defined(CONFIG_SOC_SERIES_STM32L5X) || \
+	defined(CONFIG_SOC_SERIES_STM32WBX) || \
+	defined(CONFIG_SOC_SERIES_STM32WLX)
+
+#ifdef LL_ADC_OVS_RATIO_2
+/* table for shifting oversampling mostly for ADC3 != ADC_VER_V5_V90 */
+	static const uint32_t stm32_adc_ratio_table[] = {
+		0,
+		LL_ADC_OVS_RATIO_2,
+		LL_ADC_OVS_RATIO_4,
+		LL_ADC_OVS_RATIO_8,
+		LL_ADC_OVS_RATIO_16,
+		LL_ADC_OVS_RATIO_32,
+		LL_ADC_OVS_RATIO_64,
+		LL_ADC_OVS_RATIO_128,
+		LL_ADC_OVS_RATIO_256,
+	};
+#endif /* ! ADC_VER_V5_V90 */
+
+	/*
+	 * Function to configure the oversampling ratio and shit using stm32 LL
+	 * ratio is directly the sequence->oversampling (a 2^n value)
+	 * shift is the corresponding LL_ADC_OVS_SHIFT_RIGHT_x constant
+	 */
+static void adc_stm32_oversampling(ADC_TypeDef *adc, uint8_t ratio, uint32_t shift)
+{
+	LL_ADC_SetOverSamplingScope(adc, LL_ADC_OVS_GRP_REGULAR_CONTINUED);
+#if defined(CONFIG_SOC_SERIES_STM32H7X)
+	/*
+	 * Set bits manually to circumvent bug in LL Libraries
+	 * https://github.com/STMicroelectronics/STM32CubeH7/issues/177
+	 */
+#if defined(ADC_VER_V5_V90)
+	if (adc == ADC3) {
+		MODIFY_REG(adc->CFGR2, (ADC_CFGR2_OVSS | ADC3_CFGR2_OVSR),
+			(shift | stm32_adc_ratio_table[ratio]));
+	} else {
+		MODIFY_REG(adc->CFGR2, (ADC_CFGR2_OVSS | ADC_CFGR2_OVSR),
+			(shift | (((1UL << ratio) - 1) << ADC_CFGR2_OVSR_Pos)));
+	}
+#endif /* ADC_VER_V5_V90*/
+	MODIFY_REG(adc->CFGR2, (ADC_CFGR2_OVSS | ADC_CFGR2_OVSR),
+		(shift | (((1UL << ratio) - 1) << ADC_CFGR2_OVSR_Pos)));
+#else /* CONFIG_SOC_SERIES_STM32H7X */
+	LL_ADC_ConfigOverSamplingRatioShift(adc, stm32_adc_ratio_table[ratio], shift);
+#endif /* CONFIG_SOC_SERIES_STM32H7X */
+}
+#endif /* CONFIG_SOC_SERIES_STM32xxx */
+
 static int start_read(const struct device *dev,
 		      const struct adc_sequence *sequence)
 {
@@ -416,46 +470,35 @@ static int start_read(const struct device *dev,
 	defined(CONFIG_SOC_SERIES_STM32WBX) || \
 	defined(CONFIG_SOC_SERIES_STM32WLX)
 
-static const uint32_t table_oversampling_shift[] = {
-	0,
-	LL_ADC_OVS_SHIFT_RIGHT_1,
-	LL_ADC_OVS_SHIFT_RIGHT_2,
-	LL_ADC_OVS_SHIFT_RIGHT_3,
-	LL_ADC_OVS_SHIFT_RIGHT_4,
-	LL_ADC_OVS_SHIFT_RIGHT_5,
-	LL_ADC_OVS_SHIFT_RIGHT_6,
-	LL_ADC_OVS_SHIFT_RIGHT_7,
-	LL_ADC_OVS_SHIFT_RIGHT_8,
-};
-
-	uint32_t oversampling_ratio = sequence->oversampling;
-#if defined(CONFIG_SOC_SERIES_STM32H7X)
-	/* All H7 devices' ADC1+2 is 10bit */
-	if (adc != ADC3) {
-		oversampling_ratio = 1<<sequence->oversampling;
-	}
-#endif
-	if (sequence->oversampling == 0) {
+	switch (sequence->oversampling) {
+	case 0:
 		LL_ADC_SetOverSamplingScope(adc, LL_ADC_OVS_DISABLE);
-	} else if (sequence->oversampling <= 8) {
-		LL_ADC_SetOverSamplingScope(adc, LL_ADC_OVS_GRP_REGULAR_CONTINUED);
-#if defined(CONFIG_SOC_SERIES_STM32H7X) && defined(ADC_VER_V5_V90)
-		/* Set bits manually to circumvent bug in LL Libraries
-		 * https://github.com/STMicroelectronics/STM32CubeH7/issues/177
-		 */
-		if (adc == ADC3) {
-			MODIFY_REG(adc->CFGR2, ADC_CFGR2_OVSS,
-				table_oversampling_shift[sequence->oversampling]);
-			MODIFY_REG(adc->CFGR2, ADC3_CFGR2_OVSR,
-				(oversampling_ratio - 1UL) << ADC3_CFGR2_OVSR_Pos);
-		} else {
-#endif
-			LL_ADC_ConfigOverSamplingRatioShift(adc, oversampling_ratio,
-				table_oversampling_shift[sequence->oversampling]);
-#if defined(CONFIG_SOC_SERIES_STM32H7X) && defined(ADC_VER_V5_V90)
-		}
-#endif
-	} else {
+		break;
+	case 1:
+		adc_stm32_oversampling(adc, 1, LL_ADC_OVS_SHIFT_RIGHT_1);
+		break;
+	case 2:
+		adc_stm32_oversampling(adc, 2, LL_ADC_OVS_SHIFT_RIGHT_2);
+		break;
+	case 3:
+		adc_stm32_oversampling(adc, 3, LL_ADC_OVS_SHIFT_RIGHT_3);
+		break;
+	case 4:
+		adc_stm32_oversampling(adc, 4, LL_ADC_OVS_SHIFT_RIGHT_4);
+		break;
+	case 5:
+		adc_stm32_oversampling(adc, 5, LL_ADC_OVS_SHIFT_RIGHT_5);
+		break;
+	case 6:
+		adc_stm32_oversampling(adc, 6, LL_ADC_OVS_SHIFT_RIGHT_6);
+		break;
+	case 7:
+		adc_stm32_oversampling(adc, 7, LL_ADC_OVS_SHIFT_RIGHT_7);
+		break;
+	case 8:
+		adc_stm32_oversampling(adc, 8, LL_ADC_OVS_SHIFT_RIGHT_8);
+		break;
+	default:
 		LOG_ERR("Invalid oversampling");
 		return -EINVAL;
 	}


### PR DESCRIPTION
Update zephyr oversampling to upstream fix: https://github.com/zephyrproject-rtos/zephyr/pull/38627/
Which is based on our temporary fix: #30
Also updates our temporary fix #17 
Changes verified with qualification tests.