### PR TITLE
sntp: kconfig: build sntp for native posix without NET_SOCKET_POSIX_NAMES

### DIFF
--- a/subsys/net/lib/sntp/Kconfig
+++ b/subsys/net/lib/sntp/Kconfig
@@ -4,7 +4,7 @@
 menuconfig SNTP
 	bool "SNTP (Simple Network Time Protocol)"
 	depends on NET_SOCKETS
-	depends on NET_SOCKETS_POSIX_NAMES || POSIX_API
+	depends on NET_SOCKETS_POSIX_NAMES || POSIX_API || ARCH_POSIX
 	help
 	  Enable SNTP client library
 


### PR DESCRIPTION
Allow build sntp for native posix without NET_SOCKET_POSIX_NAMES enabled

Signed-off-by: Andrii Zakharchenko <a.zakharchenko@micro-solutions.pl>