### PR TITLE
arch: add flash alignment kconfig

### DIFF
--- a/arch/Kconfig
+++ b/arch/Kconfig
@@ -199,6 +199,14 @@ config FLASH_BASE_ADDRESS
 	  normally set by the board's defconfig file and the user should generally
 	  avoid modifying it via the menu configuration.
 
+config FLASH_ALIGNMENT_WORD_SIZE_BYTES
+	int "Size of the flash word"
+	default 8
+	help
+	  Sets the alignment size of a flash word. It is
+	  normally set by the board's defconfig file and the user should generally
+	  avoid modifying it via the menu configuration.
+
 endif # ARM || ARM64 || ARC || NIOS2 || X86
 
 if ARCH_HAS_TRUSTED_EXECUTION

--- a/drivers/flash/Kconfig
+++ b/drivers/flash/Kconfig
@@ -58,12 +58,6 @@ config FLASH_PAGE_LAYOUT
 	help
 	  Enables API for retrieving the layout of flash memory pages.
 
-config FLASH_ALIGNMENT_WORD_SIZE_BYTES
-	int "Size of the flash word"
-	default 8
-	help
-	  Sets the alignment size of a flash word.
-
 source "drivers/flash/Kconfig.at45"
 
 source "drivers/flash/Kconfig.esp32"


### PR DESCRIPTION
Move flash alignment kconfig setting to

the arch to remove dependencies

Signed-of-by: <hein.wessels@nobleo.nl>