### PR TITLE
mcuboot: flash: remove redundent kconfig dependency

### DIFF
--- a/drivers/flash/Kconfig
+++ b/drivers/flash/Kconfig
@@ -58,12 +58,6 @@ config FLASH_PAGE_LAYOUT
 	help
 	  Enables API for retrieving the layout of flash memory pages.
 
-config FLASH_ALIGNMENT_WORD_SIZE_BYTES
-	int "Size of the flash word"
-	default 8
-	help
-	  Sets the alignment size of a flash word.
-
 source "drivers/flash/Kconfig.at45"
 
 source "drivers/flash/Kconfig.esp32"

--- a/include/dfu/mcuboot.h
+++ b/include/dfu/mcuboot.h
@@ -65,16 +65,15 @@ extern "C" {
 #define BOOT_IMG_VER_STRLEN_MAX 25  /* 255.255.65535.4294967295\0 */
 
 /* Trailer: */
-#ifndef CONFIG_FLASH_ALIGNMENT_WORD_SIZE_BYTES
-#warning "expecting flash alignment to be defined, using 8 bytes as default"
-#define CONFIG_FLASH_ALIGNMENT_WORD_SIZE_BYTES 8
+#define FLASH_WRITE_BLOCK_SIZE \
+	DT_PROP(DT_CHOSEN(zephyr_flash), write_block_size)
+
+#ifndef BOOT_MAX_ALIGN
+#define BOOT_MAX_ALIGN (FLASH_WRITE_BLOCK_SIZE > 16 ? FLASH_WRITE_BLOCK_SIZE : 8)
 #endif
 
-#define BOOT_MAX_ALIGN          CONFIG_FLASH_ALIGNMENT_WORD_SIZE_BYTES
-
 #ifndef BOOT_MAGIC_SZ
-#define BOOT_MAGIC_SZ (CONFIG_FLASH_ALIGNMENT_WORD_SIZE_BYTES > 16 ?\
-						CONFIG_FLASH_ALIGNMENT_WORD_SIZE_BYTES : 16)
+#define BOOT_MAGIC_SZ (FLASH_WRITE_BLOCK_SIZE > 16 ? FLASH_WRITE_BLOCK_SIZE : 16)
 #endif
 
 #define BOOT_TRAILER_IMG_STATUS_OFFS(bank_area) ((bank_area)->fa_size -\

--- a/west.yml
+++ b/west.yml
@@ -95,7 +95,7 @@ manifest:
     - name: mcuboot
       repo-path: mcuboot
       remote: optima
-      revision: 267ece9b5c7f79d55e1bf680e5bb79640354ece5
+      revision: 218c4a519507c67eb4d41663b76cffd7581c1f2a
       path: bootloader/mcuboot
     - name: mcumgr
       repo-path: mynewt-mcumgr


### PR DESCRIPTION
Removing new kconfig setting that is already available in dts.

Signed-off-by: Hein Wessels <hein.wessels@nobleo.nl>