### PR TITLE
drivers: uart: STM32: restored 9bit support in uart configuration

### DIFF
--- a/drivers/serial/uart_stm32.c
+++ b/drivers/serial/uart_stm32.c
@@ -371,7 +371,10 @@ static int uart_stm32_configure(const struct device *dev,
 #ifndef LL_USART_DATAWIDTH_7B
 	    || (cfg->data_bits == UART_CFG_DATA_BITS_7)
 #endif /* LL_USART_DATAWIDTH_7B */
-	    || (cfg->data_bits == UART_CFG_DATA_BITS_9)) {
+#ifndef LL_USART_DATAWIDTH_9B
+	    || (cfg->data_bits == UART_CFG_DATA_BITS_9)
+#endif /* LL_USART_DATAWIDTH_9B */
+		) {
 		return -ENOTSUP;
 	}
 


### PR DESCRIPTION
Restored change to allow configure uart in 9 bit mode when
LL_USART_DATAWIDTH_9B is enabled instead of returning ENOTSUP code.

Signed-off-by: Adam Borowski <a.borowski@micro-solutions.pl>