### PR TITLE
drivers: spi: stm32: force clock source to PCLK

### DIFF
--- a/drivers/spi/spi_ll_stm32.c
+++ b/drivers/spi/spi_ll_stm32.c
@@ -14,6 +14,7 @@ LOG_MODULE_REGISTER(spi_ll_stm32);
 #include <kernel.h>
 #include <soc.h>
 #include <stm32_ll_spi.h>
+#include <stm32_ll_rcc.h>
 #include <errno.h>
 #include <drivers/spi.h>
 #include <toolchain.h>
@@ -800,6 +801,7 @@ static int spi_stm32_init(const struct device *dev)
 {
 	struct spi_stm32_data *data __attribute__((unused)) = dev->data;
 	const struct spi_stm32_config *cfg = dev->config;
+	SPI_TypeDef *spi = cfg->spi;
 	int err;
 
 	if (clock_control_on(DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE),
@@ -807,6 +809,17 @@ static int spi_stm32_init(const struct device *dev)
 		LOG_ERR("Could not enable SPI clock");
 		return -EIO;
 	}
+
+#if defined(CONFIG_SOC_SERIES_STM32H7X)
+	if (spi == SPI1 || spi == SPI2 || spi == SPI3) {
+		/* SPI 1, 2, and 3 defaults clock source to PLL1
+		 * where the drivers expects the PCLK. Other sources
+		 * than the PCLK cannot be used as they are not defined
+		 * in `stm32_clock.h`, and thus not selectable in the DTS.
+		 */
+		LL_RCC_SetSPIClockSource(LL_RCC_SPI123_CLKSOURCE_CLKP);
+	}
+#endif
 
 	/* Configure dt provided device signals when available */
 	err = stm32_dt_pinctrl_configure(cfg->pinctrl_list,


### PR DESCRIPTION
The STM32H7 family defaults the SPI1,2,3 clock source
to PLL1. This changes it to PCLK, which is
used by the drivers

Signed-off-by: Hein Wessels <hein.wessels@nobleo.nl>