### PR TITLE
drivers: adc: stm32: disable circular buffer

### DIFF
--- a/samples/drivers/adc/CMakeLists.txt
+++ b/samples/drivers/adc/CMakeLists.txt
@@ -6,3 +6,6 @@ find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
 project(ADC)
 
 target_sources(app PRIVATE src/main.c)
+
+
+zephyr_linker_sources(SECTIONS custom-sections.ld)

--- a/samples/drivers/adc/custom-sections.ld
+++ b/samples/drivers/adc/custom-sections.ld
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2020 Jeroen van Dooren
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#include <autoconf.h>
+#include <linker/sections.h>
+#include <devicetree.h>
+
+#include <linker/linker-defs.h>
+#include <linker/linker-tool.h>
+
+#ifdef CONFIG_SOC_SERIES_STM32H7X
+#if DT_NODE_HAS_STATUS(DT_NODELABEL(sram4), okay)
+
+SECTION_PROLOGUE (shared_sram4, ABSOLUTE(DT_REG_ADDR(DT_NODELABEL(sram4))) (NOLOAD),)
+{
+    __shared_sram4_start = .;
+    KEEP(*(SORT_BY_NAME(".shared_sram4*")))
+    __shared_sram4_end = .;
+} GROUP_DATA_LINK_IN(SRAM4, SRAM4)
+
+#endif
+
+#if DT_NODE_HAS_STATUS(DT_NODELABEL(sram1), okay)
+
+SECTION_PROLOGUE (shared_sram1, ABSOLUTE(DT_REG_ADDR(DT_NODELABEL(sram1))) (NOLOAD),)
+{
+    __shared_sram1_start = .;
+    KEEP(*(SORT_BY_NAME(".shared_sram1*")))
+    __shared_sram1_end = .;
+} GROUP_DATA_LINK_IN(SRAM1, SRAM1)
+
+#endif
+
+#endif /* CONFIG_SOC_SERIES_STM32H7X */

--- a/samples/drivers/adc/src/main.c
+++ b/samples/drivers/adc/src/main.c
@@ -41,7 +41,12 @@ static uint8_t channel_ids[ADC_NUM_CHANNELS] = {
 #endif
 };
 
-static int16_t sample_buffer[ADC_NUM_CHANNELS] __aligned(32);
+#ifdef CONFIG_SOC_SERIES_STM32H7X
+__in_section(shared_sram1, adc1,
+	     dma_ds) static volatile int16_t sample_buffer[ADC_NUM_CHANNELS] __aligned(32);
+#else
+static volatile int16_t sample_buffer[ADC_NUM_CHANNELS] __aligned(32);
+#endif
 
 struct adc_channel_cfg channel_cfg = {
 	.gain = ADC_GAIN,


### PR DESCRIPTION
Fixes two things:
- The DMA was erroneously set to run in Circular mode.
- The ADC sample app's databuffer was not placed in SRAM1 as specified by the reference manual

Signed-off-by: Hein Wessels <hein.wessels@nobleo.nl>