### PR TITLE
toolchain: gcc: rename popcount to avoid conflict with C++20

### DIFF
--- a/include/toolchain/gcc.h
+++ b/include/toolchain/gcc.h
@@ -202,7 +202,7 @@ do {                                                                    \
 #define likely(x)   __builtin_expect((bool)!!(x), true)
 #define unlikely(x) __builtin_expect((bool)!!(x), false)
 
-#define popcount(x) __builtin_popcount(x)
+#define POPCOUNT(x) __builtin_popcount(x)
 
 #ifndef __no_optimization
 #define __no_optimization __attribute__((optimize("-O0")))

--- a/subsys/bluetooth/mesh/lpn.c
+++ b/subsys/bluetooth/mesh/lpn.c
@@ -691,10 +691,10 @@ static inline int group_popcount(atomic_t *target)
 	int i, count = 0;
 
 	for (i = 0; i < ARRAY_SIZE(bt_mesh.lpn.added); i++) {
-		count += popcount(atomic_get(&target[i]));
+		count += POPCOUNT(atomic_get(&target[i]));
 	}
 #else
-	return popcount(atomic_get(target));
+	return POPCOUNT(atomic_get(target));
 #endif
 }
 

--- a/subsys/bluetooth/mesh/transport.c
+++ b/subsys/bluetooth/mesh/transport.c
@@ -1001,7 +1001,7 @@ static inline int32_t ack_timeout(struct seg_rx *rx)
 	to = 150 + (ttl * 50U);
 
 	/* 100 ms for every not yet received segment */
-	to += ((rx->seg_n + 1) - popcount(rx->block)) * 100U;
+	to += ((rx->seg_n + 1) - POPCOUNT(rx->block)) * 100U;
 
 	/* Make sure we don't send more frequently than the duration for
 	 * each packet (default is 300ms).

--- a/tests/kernel/common/src/bitarray.c
+++ b/tests/kernel/common/src/bitarray.c
@@ -344,7 +344,7 @@ size_t get_bitarray_popcnt(sys_bitarray_t *ba)
 	unsigned int idx;
 
 	for (idx = 0; idx < ba->num_bundles; idx++) {
-		popcnt += popcount(ba->bundles[idx]);
+		popcnt += POPCOUNT(ba->bundles[idx]);
 	}
 
 	return popcnt;

--- a/tests/kernel/mem_protect/userspace/src/main.c
+++ b/tests/kernel/mem_protect/userspace/src/main.c
@@ -815,7 +815,7 @@ void test_object_recycle(void)
 		     "object wasn't marked as initialized");
 
 	for (int i = 0; i < CONFIG_MAX_THREAD_BYTES; i++) {
-		perms_count += popcount(ko->perms[i]);
+		perms_count += POPCOUNT(ko->perms[i]);
 	}
 
 	zassert_true(perms_count == 1, "invalid number of thread permissions");


### PR DESCRIPTION
Backports a bugfix from upstream so that we can shift to the Zephyr SDK 0.16 already

https://github.com/zephyrproject-rtos/zephyr/commit/3210541c8658fd34068c254f81ce4f23ba0dc839