### PR TITLE
[Bugfix][OPL-13852] Fix zephyr native-posix ld tool

### DIFF
--- a/cmake/modules/FindTargetTools.cmake
+++ b/cmake/modules/FindTargetTools.cmake
@@ -90,8 +90,10 @@ endif()
 # The 'generic' compiler and the 'target' compiler might be different,
 # so we unset the 'generic' one and thereby force the 'target' to
 # re-set it.
-unset(CMAKE_C_COMPILER)
-unset(CMAKE_C_COMPILER CACHE)
+if(NOT (COMPILER STREQUAL "host-gcc"))
+  unset(CMAKE_C_COMPILER)
+  unset(CMAKE_C_COMPILER CACHE)
+endif()
 
 # A toolchain consist of a compiler and a linker.
 # In Zephyr, toolchains require a port under cmake/toolchain/.


### PR DESCRIPTION
The PR fixes CMAKE_C_COMPILER detection for non-system gcc toolchains